### PR TITLE
feat: Add Kaniko as default builder

### DIFF
--- a/helm/yatai-deployment/templates/secret-env.yaml
+++ b/helm/yatai-deployment/templates/secret-env.yaml
@@ -22,5 +22,3 @@ stringData:
   {{- if .Values.bentoDeploymentNamespaces }}
   DEPLOYMENT_NAMESPACES: {{ join "," .Values.bentoDeploymentNamespaces | quote }}
   {{- end }}
-  DOCKER_IMAGE_BUILDER_PRIVILEGED: {{ .Values.dockerImageBuilder.privileged | quote }}
-

--- a/helm/yatai-deployment/values.yaml
+++ b/helm/yatai-deployment/values.yaml
@@ -113,7 +113,4 @@ dockerRegistry:
   secure: true
   bentoRepositoryName: yatai-bentos
 
-dockerImageBuilder:
-  privileged: false
-
 bentoDeploymentNamespaces: ['yatai']

--- a/services/image_builder.go
+++ b/services/image_builder.go
@@ -173,11 +173,6 @@ func (s *imageBuilderService) CreateImageBuilderPod(ctx context.Context, opt Cre
 	}
 
 	imageName := opt.ImageName
-	// dockerImageBuilder := commonconfig.GetDockerImageBuilderConfig()
-	if err != nil {
-		err = errors.Wrap(err, "failed to get docker image builder config")
-		return
-	}
 
 	yataiConfig, err := commonconfig.GetYataiConfig(ctx, kubeCli, consts.KubeNamespaceYataiDeploymentComponent, false)
 	if err != nil {

--- a/services/image_builder.go
+++ b/services/image_builder.go
@@ -342,7 +342,7 @@ echo "Done"
 		fmt.Sprintf("--destination=%s", imageName),
 	}
 
-	builder_image := "gcr.io/kaniko-project/executor:latest"
+	builder_image := "quay.io/bentoml/kaniko:latest"
 
 	podsCli := kubeCli.CoreV1().Pods(kubeNamespace)
 


### PR DESCRIPTION
remove buildkit and builkit-rootless to use kaniko instead

Still todos
- [x] remove option of setting `privilege` from helm chart/yatai-common/yatai-api-server-config
- [x] follow best practices for [securing kaniko](https://kurtmadel.com/posts/native-kubernetes-continuous-delivery/building-container-images-with-kubernetes/)