### PR TITLE
Feat: add 1.23 and 1.26 cluster as matrix in github workflow

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -133,6 +133,9 @@ jobs:
     needs: [triage, build-test-images]
     if: needs.triage.outputs.run-e2e == 'true'
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+       k8s-version: ["1-23", "1-26"]
     steps:
     - name: Set status in-progress
       uses: LouisBrunner/checks-action@v1.5.0
@@ -163,7 +166,7 @@ jobs:
       run: ./tests/gh-actions/install_helm.sh
 
     - name: Create KinD Cluster
-      run: kind create cluster --config tests/gh-actions/kind-cluster-1-24.yaml
+      run: kind create cluster --config tests/gh-actions/kind-cluster-${{ matrix.k8s-version }}.yaml
 
     - name: Run e2e test
       continue-on-error: true

--- a/tests/gh-actions/kind-cluster-1-23.yaml
+++ b/tests/gh-actions/kind-cluster-1-23.yaml
@@ -1,0 +1,25 @@
+# This testing option is available for testing projects that don't yet support k8s 1.25
+apiVersion: kind.x-k8s.io/v1alpha4
+kind: Cluster
+# Configure registry for KinD.
+containerdConfigPatches:
+- |-
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."$REGISTRY_NAME:$REGISTRY_PORT"]
+    endpoint = ["http://$REGISTRY_NAME:$REGISTRY_PORT"]
+# This is needed in order to support projected volumes with service account tokens.
+# See: https://kubernetes.slack.com/archives/CEKK1KTN2/p1600268272383600
+kubeadmConfigPatches:
+  - |
+    apiVersion: kubeadm.k8s.io/v1beta2
+    kind: ClusterConfiguration
+    metadata:
+      name: config
+    apiServer:
+      extraArgs:
+        "service-account-issuer": "kubernetes.default.svc"
+        "service-account-signing-key-file": "/etc/kubernetes/pki/sa.key"
+nodes:
+- role: control-plane
+  image: kindest/node:v1.23.17
+- role: worker
+  image: kindest/node:v1.23.17

--- a/tests/gh-actions/kind-cluster-1-26.yaml
+++ b/tests/gh-actions/kind-cluster-1-26.yaml
@@ -20,6 +20,6 @@ kubeadmConfigPatches:
         "service-account-signing-key-file": "/etc/kubernetes/pki/sa.key"
 nodes:
 - role: control-plane
-  image: kindest/node:v1.24.7@sha256:577c630ce8e509131eab1aea12c022190978dd2f745aac5eb1fe65c0807eb315
+  image: kindest/node:v1.26.3
 - role: worker
-  image: kindest/node:v1.24.7@sha256:577c630ce8e509131eab1aea12c022190978dd2f745aac5eb1fe65c0807eb315
+  image: kindest/node:v1.26.3


### PR DESCRIPTION
add 1.23 and 1.26 cluster as matrix in github workflow