### PR TITLE
fix: diverging monitor exporter image env var

### DIFF
--- a/controllers/bentodeployment_controller.go
+++ b/controllers/bentodeployment_controller.go
@@ -2307,7 +2307,7 @@ monitoring.options.insecure=true`
 		monitorExporterProbePort := lastPort
 
 		monitorExporterImage := "quay.io/bentoml/bentoml-monitor-exporter:0.0.3"
-		monitorExporterImage_ := os.Getenv("INTERNAL_MONITOR_EXPORTER")
+		monitorExporterImage_ := os.Getenv("INTERNAL_IMAGES_MONITOR_EXPORTER")
 		if monitorExporterImage_ != "" {
 			monitorExporterImage = monitorExporterImage_
 		}


### PR DESCRIPTION
due to this diverging environment variable, it is not possible to select monitor exporter image from helm chart values. this pr changes yatai-deployment env key to the same used in the helm template.