### PR TITLE
feat: add default tls option logic to controller

### DIFF
--- a/controllers/bentodeployment_controller.go
+++ b/controllers/bentodeployment_controller.go
@@ -2728,11 +2728,21 @@ func (r *BentoDeploymentReconciler) generateDefaultHostname(ctx context.Context,
 	return fmt.Sprintf("%s-%s.%s", bentoDeployment.Name, bentoDeployment.Namespace, domainSuffix), nil
 }
 
+type TLSModeOpt string
+
+const (
+	TLSModeNone   TLSModeOpt = "none"
+	TLSModeAuto   TLSModeOpt = "auto"
+	TLSModeStatic TLSModeOpt = "static"
+)
+
 type IngressConfig struct {
-	ClassName   *string
-	Annotations map[string]string
-	Path        string
-	PathType    networkingv1.PathType
+	ClassName           *string
+	Annotations         map[string]string
+	Path                string
+	PathType            networkingv1.PathType
+	TLSMode             TLSModeOpt
+	StaticTLSSecretName string
 }
 
 func GetIngressConfig(ctx context.Context, cliset *kubernetes.Clientset) (ingressConfig *IngressConfig, err error) {
@@ -2772,11 +2782,31 @@ func GetIngressConfig(ctx context.Context, cliset *kubernetes.Clientset) (ingres
 		pathType = networkingv1.PathType(pathType_)
 	}
 
+	tlsMode := TLSModeNone
+	tlsModeStr := strings.TrimSpace(configMap.Data["ingress-tls-mode"])
+	if tlsModeStr != "" && tlsModeStr != "none" {
+		if tlsModeStr == "auto" || tlsModeStr == "static" {
+			tlsMode = TLSModeOpt(tlsModeStr)
+		} else {
+			fmt.Println("Invalid TLS mode:", tlsModeStr)
+			err = errors.Wrapf(err, "Invalid TLS mode: %s", tlsModeStr)
+			return
+		}
+	}
+
+	staticTLSSecretName := strings.TrimSpace(configMap.Data["ingress-static-tls-secret-name"])
+	if tlsMode == TLSModeStatic && staticTLSSecretName == "" {
+		err = errors.Wrapf(err, "TLS mode is static but ingress-static-tls-secret isn't set")
+		return
+	}
+
 	ingressConfig = &IngressConfig{
-		ClassName:   className,
-		Annotations: annotations,
-		Path:        path,
-		PathType:    pathType,
+		ClassName:           className,
+		Annotations:         annotations,
+		Path:                path,
+		PathType:            pathType,
+		TLSMode:             tlsMode,
+		StaticTLSSecretName: staticTLSSecretName,
 	}
 
 	return
@@ -2849,6 +2879,8 @@ more_set_headers "X-Yatai-Bento: %s";
 	ingressAnnotations := ingressConfig.Annotations
 	ingressPath := ingressConfig.Path
 	ingressPathType := ingressConfig.PathType
+	ingressTLSMode := ingressConfig.TLSMode
+	ingressStaticTLSSecretName := ingressConfig.StaticTLSSecretName
 
 	for k, v := range ingressAnnotations {
 		annotations[k] = v
@@ -2864,6 +2896,28 @@ more_set_headers "X-Yatai-Bento: %s";
 
 	var tls []networkingv1.IngressTLS
 
+	// set default tls from network configmap
+	switch ingressTLSMode {
+	case TLSModeNone:
+	case TLSModeAuto:
+		tls = make([]networkingv1.IngressTLS, 0, 1)
+		tls = append(tls, networkingv1.IngressTLS{
+			Hosts:      []string{internalHost},
+			SecretName: kubeName,
+		})
+
+	case TLSModeStatic:
+		tls = make([]networkingv1.IngressTLS, 0, 1)
+		tls = append(tls, networkingv1.IngressTLS{
+			Hosts:      []string{internalHost},
+			SecretName: ingressStaticTLSSecretName,
+		})
+	default:
+		err = errors.Wrapf(err, "TLS mode is invalid: %s", ingressTLSMode)
+		return
+	}
+
+	// override default tls if BentoDeployment defines its own tls section
 	if opt.bentoDeployment.Spec.Ingress.TLS != nil && opt.bentoDeployment.Spec.Ingress.TLS.SecretName != "" {
 		tls = make([]networkingv1.IngressTLS, 0, 1)
 		tls = append(tls, networkingv1.IngressTLS{

--- a/helm/yatai-deployment/templates/configmap-network.yaml
+++ b/helm/yatai-deployment/templates/configmap-network.yaml
@@ -21,4 +21,17 @@ data:
   {{- if .Values.layers.network.domainSuffix }}
   domain-suffix: {{ .Values.layers.network.domainSuffix }}
   {{- end }}
-
+  {{- if .Values.layers.network.ingressTlsMode }}
+  {{- $validModes := (list "none" "auto" "static") }}
+  {{- $mode := .Values.layers.network.ingressTlsMode }}
+  {{- if not (has $mode $validModes) }}
+    {{- fail (printf "Invalid value for ingressTlsMode: %s. Expected one of: %s" $mode $validModes) }}
+  {{- end }}
+  {{- if and (eq $mode "static") (eq (trim .Values.layers.network.ingressStaticTlsSecretName) "") }}
+    {{- fail "ingressStaticTlsSecretName cannot be an empty string when ingressTlsMode is set to 'static'" }}
+  {{- end }}
+  ingress-tls-mode: {{ .Values.layers.network.ingressTlsMode | quote }}
+  {{- if .Values.layers.network.ingressStaticTlsSecretName }}
+  ingress-static-tls-secret-name: {{ .Values.layers.network.ingressStaticTlsSecretName | quote }}
+  {{- end }}
+  {{- end }}

--- a/helm/yatai-deployment/values.yaml
+++ b/helm/yatai-deployment/values.yaml
@@ -85,6 +85,11 @@ layers:
     ingressPath: /
     ingressPathType: ImplementationSpecific
 
+    # can be one of "none", "auto", "static"
+    ingressTlsMode: "none"
+    # if ingressTlsMode is "static" ingressStaticTlsSecretName must not be empty
+    ingressStaticTlsSecretName: ""
+
     # To configure DNS for Yatai BentoDeployment, take an External IP or CNAME from setting up networking, and configure it with your DNS provider as follows:
     #   If the networking layer produced an External IP address, then configure a wildcard `A` record for the domain:
     #       ```

--- a/tests/e2e/installation_test_ingress.sh
+++ b/tests/e2e/installation_test_ingress.sh
@@ -3,8 +3,9 @@
 set -xe
 
 # install loadbalancer
-#
+
 kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.13.7/config/manifests/metallb-native.yaml
+kubectl wait --namespace metallb-system --for=condition=ready pod --selector=app=metallb --timeout=90s
 kubectl apply -f https://kind.sigs.k8s.io/examples/loadbalancer/metallb-config.yaml
 
 # install ingress, needs to happen before yatai-deployment, otherwise quick-install-yatai-deployment.sh will complain


### PR DESCRIPTION
add ingress tls options to configmap

refactor, allow auto vs static modes

adapt helm chart to changes

renamt to secret name

add validations

fix helm validation

parametrize tls mode in quick installation script

test installation with ingress

validate ingress/tls behaviour

add ingress test action

default installtion tls mode should be none

use my image

make kind ingress compatible

need an example where ingress is enabled

polish test code

rename example with ingress

fix template condition

commit before we delete it

delete env vars for local testing

make sure configmap is refreshed

add gh action for all three modes

for 1-26 we need the kind cluster config too

fix lynt issues

fix lint

Signed-off-by: David van der Spek <vanderspek.david@gmail.com>